### PR TITLE
Cockpit enablement for Leap

### DIFF
--- a/pkg/lib/python.js
+++ b/pkg/lib/python.js
@@ -19,8 +19,7 @@
 
 import cockpit from "cockpit";
 
-// FIXME: eventually convert all images to python 3
-const pyinvoke = ["sh", "-ec", "exec $(which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python) -c \"$@\"", "--"];
+const pyinvoke = ["sh", "-ec", "exec $(command -v /usr/libexec/platform-python || command -v python3) -c \"$@\"", "--"];
 
 export function spawn (script_pieces, args, options) {
     const script = (typeof script_pieces == "string")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -46,11 +46,22 @@ def fix_hostkey(m, key=None):
 
 
 def break_bridge(m):
-    m.execute("ln -snf /bin/false /usr/local/bin/cockpit-bridge")
+    # we really want to get a "not found" in the shell, not a "permission denied" (which we would get with a
+    # non-executable present file or link)
+    m.execute("""
+        mkdir -p /tmp/overlay /tmp/work
+        mount -t overlay overlay -o lowerdir=/usr/bin,upperdir=/tmp/overlay,workdir=/tmp/work /usr/bin
+        rm /usr/bin/cockpit-bridge
+        """)
 
 
 def fix_bridge(m):
-    m.execute("rm /usr/local/bin/cockpit-bridge")
+    # umount lives in /usr, so needs a little dance for the EBUSY
+    m.execute("""
+        umount -l /usr/bin
+        while mountpoint -q /usr/bin; do sleep 0.5; done
+        rm -rf /tmp/overlay /tmp/work /tmp/umount
+        """)
 
 
 def check_failed_state(b, expected_title):
@@ -722,6 +733,7 @@ class TestMultiMachine(MachineCase):
                                     '.* host key for server has changed to: .*',
                                     '.* spawning remote bridge failed .*',
                                     '.*: bridge failed: .*',
+                                    '.*: cockpit-bridge: command not found',
                                     '.*: received truncated .*',
                                     '.*: Socket error: disconnected',
                                     '.*: host key for this server changed key type: .*',

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -494,6 +494,8 @@ Recommends: system-logos
 Suggests: sssd-dbus
 %if 0%{?suse_version}
 Requires(pre): permissions
+Requires: distribution-logos
+Requires: wallpaper-branding
 %endif
 # for cockpit-desktop
 Suggests: python3

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -725,14 +725,16 @@ Dummy package from building optional packages only; never install or publish me.
 Summary: Cockpit user interface for storage, using udisks
 Requires: cockpit-shell >= %{required_base}
 Requires: udisks2 >= 2.9
+Requires: %{__python3}
+%if 0%{?suse_version}
+Requires: libudisks2-0_lvm2 >= 2.9
+Recommends: multipath-tools
+Requires: python3-dbus-python
+%else
 Recommends: udisks2-lvm2 >= 2.9
 Recommends: udisks2-iscsi >= 2.9
 Recommends: device-mapper-multipath
 Recommends: clevis-luks
-Requires: %{__python3}
-%if 0%{?suse_version}
-Requires: python3-dbus-python
-%else
 Requires: python3-dbus
 %endif
 BuildArch: noarch

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -59,6 +59,7 @@ Source99:       README.packaging
 Source98:       package-lock.json
 Source97:       node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
+Patch1:         0001-selinux-allow-login-to-read-motd-file.patch
 
 # Experimental Python support
 %if !%{defined cockpit_enable_python}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -141,6 +141,8 @@ BuildRequires: libpcp_import1
 BuildRequires: openssh
 BuildRequires: distribution-logos
 BuildRequires: wallpaper-branding
+# needed for /var/lib/pcp directory ownership
+BuildRequires: pcp
 %else
 BuildRequires: pcp-libs-devel
 BuildRequires: openssh-clients

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -66,7 +66,6 @@ Patch3:         suse-microos-branding.patch
 Patch4:         css-overrides.patch
 Patch5:         storage-btrfs.patch
 # SLE Micro specific patches
-Patch100:       remove-pwscore.patch
 Patch101:       hide-pcp.patch
 Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
 
@@ -218,7 +217,6 @@ BuildRequires:  python3-tox-current-env
 
 # SLE Micro specific patches
 %if 0%{?is_smo}
-%patch100 -p1
 %patch101 -p1
 %patch102 -p1
 %endif

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -87,9 +87,11 @@ Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{v
 %endif
 
 # Ship custom SELinux policy (but not for cockpit-appstream)
+%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version}
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
 %define selinux_configure_arg --enable-selinux-policy=%{selinuxtype}
+%endif
 %endif
 
 BuildRequires: gcc
@@ -143,6 +145,7 @@ BuildRequires: gdb
 BuildRequires: xmlto
 
 BuildRequires:  selinux-policy
+BuildRequires:  selinux-policy-%{selinuxtype}
 BuildRequires:  selinux-policy-devel
 
 # This is the "cockpit" metapackage. It should only
@@ -311,7 +314,16 @@ rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-storage
 
 sed -i "s|%{buildroot}||" *.list
 
-%if ! 0%{?suse_version}
+%if 0%{?suse_version}
+# setroubleshoot not yet in
+rm -r %{buildroot}%{_datadir}/cockpit/selinux
+rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
+# remove brandings with stale symlinks. Means they don't match
+# the distro.
+pushd %{buildroot}/%{_datadir}/cockpit/branding
+find -L * -type l -printf "%H\n" | sort -u | xargs rm -rv
+popd
+%else
 %global _debugsource_packages 1
 %global _debuginfo_subpackages 0
 
@@ -601,7 +613,7 @@ The Cockpit component for managing networking.  This package uses NetworkManager
 
 %endif
 
-%if 0%{?rhel} == 0
+%if 0%{?rhel} == 0 && !0%{?suse_version}
 
 %package selinux
 Summary: Cockpit SELinux package

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -49,8 +49,8 @@ Summary:        Web Console for Linux servers
 License:        LGPL-2.1-or-later
 URL:            https://cockpit-project.org/
 
-Version:        0
-Release:        1%{?dist}
+Version:        293
+Release:        0
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 
 # Experimental Python support

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -222,7 +222,7 @@ touch node_modules/.stamp
 
 exec 2>&1
 PKG_NAME="Cockpit"
-echo %version > .tarball
+echo "m4_define(VERSION_NUMBER, %version)" > version.m4
 autoreconf -fvi -I tools
 #
 %configure \

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -397,6 +397,7 @@ ls --hide={default,kubernetes,opensuse,registry,sle-micro,suse} | xargs rm -rv
 popd
 # need this in SUSE as post build checks dislike stale symlinks
 install -m 644 -D /dev/null %{buildroot}/run/cockpit/motd
+install -m 644 -D /dev/null %{buildroot}/usr/share/cockpit/branding/opensuse/default-1920x1200.jpg ||:
 # remove files of not installable packages
 rm -r %{buildroot}%{_datadir}/cockpit/sosreport
 rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -63,6 +63,7 @@ Patch1:         0001-selinux-allow-login-to-read-motd-file.patch
 # SLE Micro specific patches
 Patch100:       remove-pwscore.patch
 Patch101:       hide-pcp.patch
+Patch102:       css-overrides.patch
 
 # Experimental Python support
 %if !%{defined cockpit_enable_python}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -114,14 +114,14 @@ BuildRequires: libssh-devel >= 0.8.5
 BuildRequires: openssl-devel
 BuildRequires: gnutls-devel >= 3.4.3
 BuildRequires: zlib-devel
-BuildRequires: krb5-devel >= 1.11
+BuildRequires: pkgconfig(krb5) >= 1.11
 BuildRequires: libxslt-devel
 BuildRequires: glib-networking
 BuildRequires: sed
 
 BuildRequires: glib2-devel >= 2.50.0
 # this is for runtimedir in the tls proxy ace21c8879
-BuildRequires: systemd-devel >= 235
+BuildRequires: pkgconfig(libsystemd) >= 235
 %if 0%{?suse_version}
 BuildRequires: distribution-release
 BuildRequires: libpcp-devel

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -69,6 +69,15 @@ Patch5:         storage-btrfs.patch
 Patch101:       hide-pcp.patch
 Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
 
+# Leap specific patch
+
+%if 0%{?is_smo}
+# Ensure we do not affect Micro with SLE/Leap specifi patches
+%else
+%if 0%{?sle_version} >= 150400 && 0%{?sle_version} <= 150700
+Patch103:       0004-leap-gnu11.patch
+%endif
+%endif
 # Experimental Python support
 %if !%{defined cockpit_enable_python}
 %define cockpit_enable_python 0
@@ -103,10 +112,13 @@ Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
 %endif
 
 # Ship custom SELinux policy (but not for cockpit-appstream)
-%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version}
+# SLES / Leap 15 does not have selinux-policy. TW and SLE Micro does.
+%define with_selinux 0
+%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1500
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
-%define selinux_configure_arg --enable-selinux-policy=%{selinuxtype}
+%define with_selinux 1
+%define selinux_policy_version %(rpm --quiet -q selinux-policy && rpm -q --queryformat "%{V}-%{R}" selinux-policy || echo 1)
 %endif
 %endif
 
@@ -162,9 +174,11 @@ BuildRequires: gdb
 # For documentation
 BuildRequires: xmlto
 
+%if 0%{?with_selinux}
 BuildRequires:  selinux-policy
 BuildRequires:  selinux-policy-%{selinuxtype}
 BuildRequires:  selinux-policy-devel
+%endif
 
 # for rebuilding nodejs bits
 BuildRequires: npm
@@ -219,6 +233,10 @@ BuildRequires:  python3-tox-current-env
 %if 0%{?is_smo}
 %patch101 -p1
 %patch102 -p1
+%else
+%if 0%{?sle_version} >= 150400 && 0%{?sle_version} <= 150700
+%patch103 -p1
+%endif
 %endif
 
 cp %SOURCE1 tools/cockpit.pam
@@ -235,9 +253,10 @@ echo "m4_define(VERSION_NUMBER, %version)" > version.m4
 autoreconf -fvi -I tools
 #
 %configure \
-    %{?selinux_configure_arg} \
+    --disable-silent-rules \
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
+    --with-selinux-config-type=etc_t \
 %if 0%{?suse_version}
     --docdir=%_defaultdocdir/%{name} \
 %endif
@@ -249,10 +268,12 @@ autoreconf -fvi -I tools
     --disable-ssh \
 %endif
 
-make -f /usr/share/selinux/devel/Makefile cockpit.pp
-bzip2 -9 cockpit.pp
+make -j4 %{?extra_flags} all
 
-%make_build
+%if 0%{?with_selinux}
+    make -f /usr/share/selinux/devel/Makefile cockpit.pp
+    bzip2 -9 cockpit.pp
+%endif
 
 %check
 make -j$(nproc) check
@@ -275,12 +296,13 @@ install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
 
-# selinux
-install -D -m 644 %{name}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
-install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_session_selinux.8cockpit
-install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_ws_selinux.8cockpit
-# create this directory in the build root so that %ghost sees the desired mode
-install -d -m 700 %{buildroot}%{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+%if 0%{?with_selinux}
+    install -D -m 644 %{name}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
+    install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_session_selinux.8cockpit
+    install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_ws_selinux.8cockpit
+    # create this directory in the build root so that %ghost sees the desired mode
+    install -d -m 700 %{buildroot}%{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+%endif
 
 # SUSE branding
 mkdir -p %{buildroot}%{_datadir}/cockpit/branding/suse
@@ -533,8 +555,10 @@ Summary: Cockpit Web Service
 Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.50.0
-Requires: (selinux-policy >= %{_selinux_policy_version} if selinux-policy-%{selinuxtype})
+%if 0%{?with_selinux}
+Requires: (selinux-policy >= %{selinux_policy_version} if selinux-policy-%{selinuxtype})
 Requires(post): (policycoreutils if selinux-policy-%{selinuxtype})
+%endif
 Conflicts: firewalld < 0.6.0-1
 Recommends: sscg >= 2.3
 Recommends: system-logos
@@ -603,10 +627,12 @@ authentication via sssd/FreeIPA.
 %{_libexecdir}/cockpit-certificate-helper
 %{?suse_version:%verify(not mode) }%attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
 %{_datadir}/cockpit/branding
+%if 0%{?with_selinux}
 %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
 %{_mandir}/man8/%{name}_session_selinux.8cockpit.*
 %{_mandir}/man8/%{name}_ws_selinux.8cockpit.*
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+%endif
 
 %pre ws
 getent group cockpit-ws >/dev/null || groupadd -r cockpit-ws

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -583,6 +583,12 @@ if [ "$1" = 1 ]; then
 %endif
     chmod 644 /etc/cockpit/disallowed-users
 fi
+# switch old self-signed cert group from cockpit-wsintance to cockpit-ws on upgrade
+if [ "$1" = 2 ]; then
+    certfile=/etc/cockpit/ws-certs.d/0-self-signed.cert
+    test -f $certfile && stat -c '%G' $certfile | grep -q cockpit-wsinstance && chgrp cockpit-ws $certfile
+fi
+
 %if 0%{?suse_version}
 %set_permissions %{_libexecdir}/cockpit-session
 %endif

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -15,6 +15,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 #
 
+#
 # This file is maintained at the following location:
 # https://github.com/cockpit-project/cockpit/blob/main/tools/cockpit.spec
 #
@@ -52,6 +53,8 @@ URL:            https://cockpit-project.org/
 Version:        293
 Release:        0
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
+Source1:        cockpit.pam
+Source2:        cockpit-rpmlintrc
 
 # Experimental Python support
 %if !%{defined cockpit_enable_python}
@@ -186,6 +189,8 @@ BuildRequires:  python3-tox-current-env
 
 %prep
 %setup -q -n cockpit-%{version}
+%autopatch -p1
+cp %SOURCE1 tools/cockpit.pam
 
 %build
 %configure \
@@ -323,6 +328,8 @@ rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.me
 pushd %{buildroot}/%{_datadir}/cockpit/branding
 find -L * -type l -printf "%H\n" | sort -u | xargs rm -rv
 popd
+# need this in SUSE as post build checks dislike stale symlinks
+install -m 644 -D /dev/null %{buildroot}/run/cockpit/motd
 # remove files of not installable packages
 rm -r %{buildroot}%{_datadir}/cockpit/sosreport
 rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml
@@ -480,10 +487,14 @@ authentication via sssd/FreeIPA.
 %dir %{_sysconfdir}/cockpit
 %config(noreplace) %{_sysconfdir}/cockpit/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
+# dir is not owned by pam in openSUSE
+%dir %{_sysconfdir}/motd.d
 # created in %post, so that users can rm the files
 %ghost %{_sysconfdir}/issue.d/cockpit.issue
 %ghost %{_sysconfdir}/motd.d/cockpit
 %ghost %attr(0644, root, root) %{_sysconfdir}/cockpit/disallowed-users
+%ghost %dir /run/cockpit
+%ghost /run/cockpit/motd
 %dir %{_datadir}/cockpit/motd
 %{_datadir}/cockpit/motd/update-motd
 %{_datadir}/cockpit/motd/inactive.motd

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -55,6 +55,7 @@ Release:        0
 Source0:        cockpit-%{version}.tar
 Source1:        cockpit.pam
 Source2:        cockpit-rpmlintrc
+Source3:        cockpit-suse-theme.tar
 Source99:       README.packaging
 Source98:       package-lock.json
 Source97:       node_modules.spec.inc
@@ -204,8 +205,7 @@ BuildRequires:  python3-tox-current-env
 %endif
 
 %prep
-%setup -q -n cockpit-%{version}
-%patch0 -p1
+%setup -q -n cockpit-%{version} -a 3
 %patch1 -p1
 
 %if 0%{?sle_version}
@@ -258,6 +258,13 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
+
+mkdir -p %{buildroot}%{_datadir}/cockpit/branding/suse
+pushd cockpit-suse-theme
+cp src/css-overrides.css %{buildroot}%{_datadir}/cockpit/branding/suse
+cp src/fonts.css %{buildroot}%{_datadir}/cockpit/branding/suse
+cp -a src/fonts %{buildroot}%{_datadir}/cockpit/branding/suse
+popd
 
 # Build the package lists for resource packages
 # cockpit-bridge is the basic dependency for all cockpit-* packages, so centrally own the page directory
@@ -360,7 +367,7 @@ rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.me
 # remove brandings with stale symlinks. Means they don't match
 # the distro.
 pushd %{buildroot}/%{_datadir}/cockpit/branding
-ls --hide={default,kubernetes,opensuse,registry,sle-micro} | xargs rm -rv
+ls --hide={default,kubernetes,opensuse,registry,sle-micro,suse} | xargs rm -rv
 popd
 # need this in SUSE as post build checks dislike stale symlinks
 install -m 644 -D /dev/null %{buildroot}/run/cockpit/motd

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -267,8 +267,13 @@ make -j$(nproc) check
 # In obs we get  write error: stdout
 %make_install | tee make_install.log
 make install-tests DESTDIR=%{buildroot}
+%if 0%{?suse_version} > 1500
+mkdir -p $RPM_BUILD_ROOT%{_pam_vendordir}
+install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_pam_vendordir}/cockpit
+%else
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
+%endif
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
 
@@ -356,6 +361,11 @@ for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-ws
     rm -f %{buildroot}/%{_libexecdir}/$libexec
 done
 rm -r %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
+%if 0%{?suse_version} > 1500
+rm -r %{buildroot}/%{_pam_vendordir}
+%else
+rm -r %{buildroot}/%{_sysconfdir}/pam.d
+%endif
 rm -f %{buildroot}/%{_libdir}/security/pam_*
 rm -f %{buildroot}/usr/bin/cockpit-bridge
 rm -f %{buildroot}%{_libexecdir}/cockpit-ssh
@@ -555,7 +565,11 @@ authentication via sssd/FreeIPA.
 %doc %{_mandir}/man8/pam_ssh_add.8.gz
 %dir %{_sysconfdir}/cockpit
 %config(noreplace) %{_sysconfdir}/cockpit/ws-certs.d
+%if 0%{?suse_version} > 1500
+%{_pam_vendordir}/cockpit
+%else
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
+%endif
 # dir is not owned by pam in openSUSE
 %dir %{_sysconfdir}/motd.d
 # created in %post, so that users can rm the files
@@ -604,6 +618,12 @@ getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance 
 if %{_sbindir}/selinuxenabled 2>/dev/null; then
     %selinux_relabel_pre -s %{selinuxtype}
 fi
+%if 0%{?suse_version} > 1500
+# Prepare for migration to /usr/lib; save any old .rpmsave
+for i in pam.d/cockpit ; do
+     test -f %{_sysconfdir}/${i}.rpmsave && mv -v %{_sysconfdir}/${i}.rpmsave %{_sysconfdir}/${i}.rpmsave.old ||:
+done
+%endif
 
 %post ws
 if [ -x %{_sbindir}/selinuxenabled ]; then
@@ -658,6 +678,14 @@ fi
 %if 0%{?suse_version}
 %verifyscript ws
 %verify_permissions -e %{_libexecdir}/cockpit-session
+%endif
+
+%if 0%{?suse_version} > 1500
+%posttrans ws
+# Migration to /usr/lib, restore just created .rpmsave
+for i in pam.d/cockpit ; do
+     test -f %{_sysconfdir}/${i}.rpmsave && mv -v %{_sysconfdir}/${i}.rpmsave %{_sysconfdir}/${i} ||:
+done
 %endif
 
 # -------------------------------------------------------------------------------

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -467,6 +467,9 @@ Conflicts: firewalld < 0.6.0-1
 Recommends: sscg >= 2.3
 Recommends: system-logos
 Suggests: sssd-dbus
+%if 0%{?suse_version}
+Requires(pre): permissions
+%endif
 # for cockpit-desktop
 Suggests: python3
 
@@ -520,7 +523,7 @@ authentication via sssd/FreeIPA.
 %{_libexecdir}/cockpit-desktop
 %{_libexecdir}/cockpit-certificate-ensure
 %{_libexecdir}/cockpit-certificate-helper
-%attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
+%{?suse_version:%verify(not mode) }%attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
 %{_datadir}/cockpit/branding
 %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
 %{_mandir}/man8/%{name}_session_selinux.8cockpit.*
@@ -555,7 +558,9 @@ if [ "$1" = 1 ]; then
 %endif
     chmod 644 /etc/cockpit/disallowed-users
 fi
-
+%if 0%{?suse_version}
+%set_permissions %{_libexecdir}/cockpit-session
+%endif
 %tmpfiles_create cockpit-tempfiles.conf
 %systemd_post cockpit.socket cockpit.service
 # firewalld only partially picks up changes to its services files without this
@@ -578,6 +583,11 @@ if [ -x %{_sbindir}/selinuxenabled ]; then
     %selinux_relabel_post -s %{selinuxtype}
 fi
 %systemd_postun_with_restart cockpit.socket cockpit.service
+
+%if 0%{?suse_version}
+%verifyscript ws
+%verify_permissions -e %{_libexecdir}/cockpit-session
+%endif
 
 # -------------------------------------------------------------------------------
 # Sub-packages that are part of cockpit-system in RHEL/CentOS, but separate in Fedora

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -675,6 +675,7 @@ Summary: Cockpit user interface for networking, using NetworkManager
 Requires: cockpit-bridge >= %{required_base}
 Requires: cockpit-shell >= %{required_base}
 Requires: NetworkManager >= 1.6
+Conflicts: cockpit-wicked
 # Optional components
 Recommends: NetworkManager-team
 BuildArch: noarch

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -61,6 +61,10 @@ Source98:       package-lock.json
 Source97:       node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Patch1:         0001-selinux-allow-login-to-read-motd-file.patch
+Patch2:         hide-docs.patch
+Patch3:         suse-microos-branding.patch
+Patch4:         css-overrides.patch
+Patch5:         storage-btrfs.patch
 # SLE Micro specific patches
 Patch100:       remove-pwscore.patch
 Patch101:       hide-pcp.patch
@@ -207,6 +211,10 @@ BuildRequires:  python3-tox-current-env
 %prep
 %setup -q -n cockpit-%{version} -a 3
 %patch1 -p1
+%patch2 -p1
+%patch3 -p1
+%patch4 -p1
+%patch5 -p1
 
 %if 0%{?sle_version}
 %patch100 -p1

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -360,7 +360,7 @@ rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.me
 # remove brandings with stale symlinks. Means they don't match
 # the distro.
 pushd %{buildroot}/%{_datadir}/cockpit/branding
-find -L * -type l -printf "%H\n" | sort -u | xargs rm -rv
+ls --hide={default,kubernetes,opensuse,registry,sle-micro} | xargs rm -rv
 popd
 # need this in SUSE as post build checks dislike stale symlinks
 install -m 644 -D /dev/null %{buildroot}/run/cockpit/motd

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -60,6 +60,9 @@ Source98:       package-lock.json
 Source97:       node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Patch1:         0001-selinux-allow-login-to-read-motd-file.patch
+# SLE Micro specific patches
+Patch100:       remove-pwscore.patch
+Patch101:       hide-pcp.patch
 
 # Experimental Python support
 %if !%{defined cockpit_enable_python}
@@ -201,7 +204,14 @@ BuildRequires:  python3-tox-current-env
 
 %prep
 %setup -q -n cockpit-%{version}
-%autopatch -p1
+%patch0 -p1
+%patch1 -p1
+
+%if 0%{?sle_version}
+%patch100 -p1
+%patch101 -p1
+%endif
+
 cp %SOURCE1 tools/cockpit.pam
 #
 local-npm-registry %{_sourcedir} install --also=dev --legacy-peer-deps
@@ -449,7 +459,9 @@ Requires: cockpit-bridge >= %{version}-%{release}
 Requires: shadow-utils
 %endif
 Requires: grep
+%if !0%{?sle_version}
 Requires: /usr/bin/pwscore
+%endif
 Requires: /usr/bin/date
 Provides: cockpit-shell = %{version}-%{release}
 Provides: cockpit-systemd = %{version}-%{release}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -68,7 +68,7 @@ Patch5:         storage-btrfs.patch
 # SLE Micro specific patches
 Patch100:       remove-pwscore.patch
 Patch101:       hide-pcp.patch
-Patch102:       css-overrides.patch
+Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
 
 # Experimental Python support
 %if !%{defined cockpit_enable_python}
@@ -216,9 +216,11 @@ BuildRequires:  python3-tox-current-env
 %patch4 -p1
 %patch5 -p1
 
-%if 0%{?sle_version}
+# SLE Micro specific patches
+%if 0%{?is_smo}
 %patch100 -p1
 %patch101 -p1
+%patch102 -p1
 %endif
 
 cp %SOURCE1 tools/cockpit.pam
@@ -249,6 +251,9 @@ autoreconf -fvi -I tools
     --disable-ssh \
 %endif
 
+make -f /usr/share/selinux/devel/Makefile cockpit.pp
+bzip2 -9 cockpit.pp
+
 %make_build
 
 %check
@@ -267,6 +272,14 @@ install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
 
+# selinux
+install -D -m 644 %{name}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
+install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_session_selinux.8cockpit
+install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_ws_selinux.8cockpit
+# create this directory in the build root so that %ghost sees the desired mode
+install -d -m 700 %{buildroot}%{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
+
+# SUSE branding
 mkdir -p %{buildroot}%{_datadir}/cockpit/branding/suse
 pushd cockpit-suse-theme
 cp src/css-overrides.css %{buildroot}%{_datadir}/cockpit/branding/suse
@@ -369,9 +382,6 @@ rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-storage
 sed -i "s|%{buildroot}||" *.list
 
 %if 0%{?suse_version}
-# setroubleshoot not yet in
-rm -r %{buildroot}%{_datadir}/cockpit/selinux
-rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 # remove brandings with stale symlinks. Means they don't match
 # the distro.
 pushd %{buildroot}/%{_datadir}/cockpit/branding
@@ -703,14 +713,18 @@ The Cockpit component for managing networking.  This package uses NetworkManager
 
 %endif
 
-%if 0%{?rhel} == 0 && !0%{?suse_version}
+%if 0%{?rhel} == 0 && ( 0%{?suse_version} >= 1500 || 0%{?is_smo} )
 
 %package selinux
 Summary: Cockpit SELinux package
 Requires: cockpit-bridge >= %{required_base}
 Requires: cockpit-shell >= %{required_base}
-Requires: setroubleshoot-server >= 3.3.3
-BuildArch: noarch
+Requires:       policycoreutils-python-utils >= 3.1
+# setroubleshoot not yet in SLE Micro
+%if !0%{?is_smo}
+Requires:       setroubleshoot-server >= 3.3.3
+%endif
+BuildArch:      noarch
 
 %description selinux
 This package contains the Cockpit user interface integration with the

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -323,6 +323,10 @@ rm %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-selinux.me
 pushd %{buildroot}/%{_datadir}/cockpit/branding
 find -L * -type l -printf "%H\n" | sort -u | xargs rm -rv
 popd
+# remove files of not installable packages
+rm -r %{buildroot}%{_datadir}/cockpit/sosreport
+rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml
+rm -f %{buildroot}%{_datadir}/pixmaps/cockpit-sosreport.png
 %else
 %global _debugsource_packages 1
 %global _debuginfo_subpackages 0
@@ -581,6 +585,7 @@ The Cockpit component for configuring kernel crash dumping.
 %files kdump -f kdump.list
 %{_datadir}/metainfo/org.cockpit-project.cockpit-kdump.metainfo.xml
 
+%if !0%{?suse_version}
 %package sosreport
 Summary: Cockpit user interface for diagnostic reports
 Requires: cockpit-bridge >= %{required_base}
@@ -595,6 +600,7 @@ sosreport tool.
 %files sosreport -f sosreport.list
 %{_datadir}/metainfo/org.cockpit-project.cockpit-sosreport.metainfo.xml
 %{_datadir}/pixmaps/cockpit-sosreport.png
+%endif
 
 %package networkmanager
 Summary: Cockpit user interface for networking, using NetworkManager

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -55,6 +55,7 @@ Release:        0
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 Source1:        cockpit.pam
 Source2:        cockpit-rpmlintrc
+Source99:       README.packaging
 
 # Experimental Python support
 %if !%{defined cockpit_enable_python}


### PR DESCRIPTION
Submitting changes from https://build.opensuse.org/package/show/SUSE:SLE-15-SP4:Update:Products:Micro54/cockpit + enablement on Leap 15.4+ (where we have no SELinux policy, just like in SLES). 

I quite like the with_selinux, I think that's worth considering even for upstream.

I did discuss the policy enablement on Leap with @jsegitz but he mentioned that team has no capacity for it.

Leap 15.4 doesn't get build as there seems to be a problem with tar_scm service (the obscpio for openSUSE theme is somehow missed). We plan to add it to 15.6 only, unless PM would vote for enablement in SLES (see https://jira.suse.com/browse/PED-3258).

