### PR TITLE
Leap 15 enablement jsc#PED-3258

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -111,8 +111,6 @@ Patch103:       0004-leap-gnu18-removal.patch
 %endif
 
 # Ship custom SELinux policy (but not for cockpit-appstream)
-# SLES / Leap 15 does not have selinux-policy. TW and SLE Micro does.
-%define with_selinux 0
 %if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1600 || 0%{?is_smo}
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -116,6 +116,7 @@ Patch103:       0004-leap-gnu18-removal.patch
 %if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1600 || 0%{?is_smo}
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
+%define selinux_configure_arg --enable-selinux-policy=%{selinuxtype}
 %define with_selinux 1
 %endif
 %endif

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -108,7 +108,7 @@ Patch103:       0004-leap-gnu18-removal.patch
 %endif
 
 # Ship custom SELinux policy (but not for cockpit-appstream)
-%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1600 || 0%{?is_smo}
+%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} >= 1600 || 0%{?is_smo}
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
 %define selinux_configure_arg --enable-selinux-policy=%{selinuxtype}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -70,7 +70,7 @@ Patch101:       hide-pcp.patch
 Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
 
 # For anything based on SLES 15 codebase (including Leap, SLE Micro)
-%if 0%{?sle_version} >= 150400 && 0%{?sle_version} <= 150700
+%if 0%{?suse_version} == 1500
 Patch103:       0004-leap-gnu18-removal.patch
 %endif
 # Experimental Python support
@@ -117,7 +117,6 @@ Patch103:       0004-leap-gnu18-removal.patch
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
 %define with_selinux 1
-%define selinux_policy_version %(rpm --quiet -q selinux-policy && rpm -q --queryformat "%{V}-%{R}" selinux-policy || echo 1)
 %endif
 %endif
 
@@ -234,7 +233,7 @@ BuildRequires:  python3-tox-current-env
 %patch102 -p1
 %endif
 # For anything based on SLES 15 codebase (including Leap, SLEM)
-%if 0%{?sle_version} >= 150400 && 0%{?sle_version} <= 150700
+%if 0%{?suse_version} == 1500
 %patch103 -p1
 %endif
 
@@ -558,7 +557,7 @@ Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.50.0
 %if 0%{?with_selinux}
-Requires: (selinux-policy >= %{selinux_policy_version} if selinux-policy-%{selinuxtype})
+Requires: (selinux-policy >= %{_selinux_policy_version} if selinux-policy-%{selinuxtype})
 Requires(post): (policycoreutils if selinux-policy-%{selinuxtype})
 %endif
 Conflicts: firewalld < 0.6.0-1
@@ -676,7 +675,6 @@ if [ "$1" = 2 ]; then
     test -f $certfile && stat -c '%G' $certfile | grep -q cockpit-wsinstance && chgrp cockpit-ws $certfile
 fi
 
-%if 0%{?suse_version}
 %set_permissions %{_libexecdir}/cockpit-session
 %endif
 %tmpfiles_create cockpit-tempfiles.conf

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -674,6 +674,7 @@ if [ "$1" = 2 ]; then
     test -f $certfile && stat -c '%G' $certfile | grep -q cockpit-wsinstance && chgrp cockpit-ws $certfile
 fi
 
+%if 0%{?suse_version}
 %set_permissions %{_libexecdir}/cockpit-session
 %endif
 %tmpfiles_create cockpit-tempfiles.conf

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -71,7 +71,7 @@ Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
 
 # For anything based on SLES 15 codebase (including Leap, SLE Micro)
 %if 0%{?sle_version} >= 150400 && 0%{?sle_version} <= 150700
-Patch103:       0004-leap-gnu11.patch
+Patch103:       0004-leap-gnu18-removal.patch
 %endif
 # Experimental Python support
 %if !%{defined cockpit_enable_python}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -68,11 +68,8 @@ Patch5:         storage-btrfs.patch
 # SLE Micro specific patches
 Patch101:       hide-pcp.patch
 Patch102:       0002-selinux-temporary-remove-setroubleshoot-section.patch
-
 # For anything based on SLES 15 codebase (including Leap, SLE Micro)
-%if 0%{?suse_version} == 1500
 Patch103:       0004-leap-gnu18-removal.patch
-%endif
 # Experimental Python support
 %if !%{defined cockpit_enable_python}
 %define cockpit_enable_python 0

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -113,7 +113,7 @@ Patch103:       0004-leap-gnu11.patch
 # Ship custom SELinux policy (but not for cockpit-appstream)
 # SLES / Leap 15 does not have selinux-policy. TW and SLE Micro does.
 %define with_selinux 0
-%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1500
+%if 0%{?rhel} >= 9 || 0%{?fedora} || 0%{?suse_version} > 1600 || 0%{?is_smo}
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
 %define with_selinux 1


### PR DESCRIPTION
- Backport SLE Micro with_selinux changes 
  - extra handling of cockpit-ws / selinux related docs
- add 0004-leap-gnu11.patch as gnu18 is not available on Leap