### PR TITLE
support optional TOTP for authentication

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -558,6 +558,7 @@ Suggests: sssd-dbus >= 2.6.2
 %if 0%{?suse_version}
 Requires(pre): permissions
 Requires: distribution-logos
+Requires: pam_oath
 Requires: wallpaper-branding
 %endif
 # for cockpit-desktop


### PR DESCRIPTION
pam_oath should be enabled in the cockpit pam config by appending:

auth [user_unknown=ignore success=ok] pam_oath.so usersfile=${HOME}/.pam_oath_usersfile window=20 digits=6