### PR TITLE
Revert "support optional TOTP for authentication"

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -576,7 +576,6 @@ Suggests: sssd-dbus >= 2.6.2
 %if 0%{?suse_version}
 Requires(pre): permissions
 Requires: distribution-logos
-Requires: pam_oath
 Requires: wallpaper-branding
 %endif
 # for cockpit-desktop


### PR DESCRIPTION
Revert load pam_oath, because it enforces the file for otp secrets to exist, will try again once pam_oath can have that optional.

This reverts commit 09b06fdc7a9cd12a6b43c14a13052f34ae70db2b.