### PR TITLE
Add libzypp-plugin-appdata as /apps depends on swcatalog being generated

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -898,6 +898,7 @@ Summary: Cockpit user interface for packages
 BuildArch: noarch
 Requires: cockpit-bridge >= %{required_base}
 Requires: PackageKit
+Requires: libzypp-plugin-appdata
 Recommends: python3-tracer
 # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1800468
 Requires: polkit


### PR DESCRIPTION
https://src.opensuse.org/cockpit/cockpit/pulls/30