### PR TITLE
cockpit support SUSE_PRETTY_NAME and VARIENT

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -81,6 +81,9 @@ Patch105:       fix-libexecdir.patch
 Patch106:       packagekit-single-install.patch
 Patch109:       0008-pybridge-endian-flag.patch
 Patch110:       add_preexec_cockpit.patch
+Patch111:       0001-cockpit-overview-support-SUSE_SUPPORT_PRODUCT-keys.patch
+Patch112:       0002-cockpit-kdump-support-SLE-micro-6.2.patch
+Patch113:       0003-branding-use-SUSE_SUPPORT_PRODUCT-and-SUSE_SUPPORT_P.patch
 Patch201:       remove_rh_links.patch
 
 %define build_all 1
@@ -213,7 +216,13 @@ BuildRequires:  python3-pytest-timeout
 %setup -q -n cockpit-%{version} -a 3
 %patch -P 1 -p1
 %patch -P 2 -p1
+
+%if 0%{?is_opensuse} || 0%{?suse_version} < 1600
 %patch -P 3 -p1
+%else
+%patch -P  113 -p1
+%endif
+
 %patch -P 4 -p1
 %patch -P 5 -p1
 %patch -P 6 -p1
@@ -242,6 +251,10 @@ BuildRequires:  python3-pytest-timeout
 
 %if 0%{?suse_version} >= 1600
 %patch -P 110 -p1
+%if !0%{?is_opensuse}
+%patch -P  111 -p1
+%patch -P  112 -p1
+%endif
 %endif
 
 %patch -P 201 -p1


### PR DESCRIPTION
suse now has some suse specific keys in the os release file. We need to use SUSE_PRETTY_NAME in place of PRETTY_NAME when is it is present. System will not report the correct name so we need patch cockpit to read the os_release file itself.

see https://src.opensuse.org/cockpit/cockpit/pulls/29 for patches